### PR TITLE
Feat implement cache

### DIFF
--- a/PhysicsEngine/PhysicsEngine/Body.cs
+++ b/PhysicsEngine/PhysicsEngine/Body.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,21 +15,26 @@ namespace PhysicsEngine
     {
         #region Fields
 
-        static int numberOfUnnamedBodies = 0;
+        static int numberOfUnnamedBodies;
+        static int numberOfBodies;
+        static int numberOfMassiveBodies;
 
-        readonly bool isFixed;
-        readonly bool isMassive;
-        readonly double mass = 0;
-        readonly string name;
         readonly List<TrajectoryPoint> trajectory = new();
+
+        int cacheId;
+        bool isFixed;
+        bool isMassive;
+        double mass;
+        string name;        
 
         #endregion Fields
 
         #region Properties
 
+        public int CacheId => cacheId;
         public Vector3 CurrentAcceleration { get; set; } = Vector3.Zero;
         public Vector3 CurrentPosition { get; set; }
-        public double CurrentPotentialEnergy { get; internal set; } = 0.0;
+        public double CurrentPotentialEnergy { get; set; } = 0.0;
         public Vector3 CurrentVelocity { get; set; }
         public bool IsFixed => isFixed;
         public bool IsMassive => isMassive;
@@ -44,36 +51,42 @@ namespace PhysicsEngine
 
         public Body(double pMass, Vector3 pInitialVelocity, Vector3 pInitialPosition, bool pIsMassive, bool pIsFixed, string pName)
         {
-            CurrentVelocity = pInitialVelocity;
+            Initialize(pMass, pInitialVelocity, pInitialPosition, pIsMassive, pIsFixed);
 
-            CurrentPosition = pInitialPosition;
-
-            mass = pMass;
-            isMassive = pIsMassive;
-            isFixed = pIsFixed;
             name = pName;
-
-            trajectory.Add(new TrajectoryPoint(0, pInitialPosition.X, pInitialPosition.Y, pInitialPosition.Z));
         }
 
         public Body(double pMass, Vector3 pInitialVelocity, Vector3 pInitialPosition, bool pIsMassive, bool pIsFixed)
         {
+            Initialize(pMass, pInitialVelocity, pInitialPosition, pIsMassive, pIsFixed);
+
             numberOfUnnamedBodies++;
-            CurrentVelocity = pInitialVelocity;
-
-            CurrentPosition = pInitialPosition;
-
-            mass = pMass;
-            isMassive = pIsMassive;
-            isFixed = pIsFixed;
             name = "Object" + numberOfUnnamedBodies;
-
-            trajectory.Add(new TrajectoryPoint(0, pInitialPosition.X, pInitialPosition.Z, pInitialPosition.Z));
         }
 
         #endregion Constructors
 
         #region Methods
+
+        [MemberNotNull(nameof(CurrentVelocity), nameof(CurrentPosition))]
+        public void Initialize(double pMass, Vector3 pInitialVelocity, Vector3 pInitialPosition, bool pIsMassive, bool pIsFixed)
+        {
+            numberOfBodies++;
+            CurrentVelocity = pInitialVelocity;
+            CurrentPosition = pInitialPosition;
+
+            mass = pMass;
+            isMassive = pIsMassive;
+            isFixed = pIsFixed;
+
+            if (isMassive)
+            {
+                cacheId = numberOfMassiveBodies;
+                numberOfMassiveBodies++;
+            }
+
+            trajectory.Add(new TrajectoryPoint(0, pInitialPosition.X, pInitialPosition.Y, pInitialPosition.Z));
+        }
 
         public void AppendPointToTrajectory(TrajectoryPoint pPoint) => trajectory.Add(pPoint);
         /// <summary>

--- a/PhysicsEngine/PhysicsEngine/Body.cs
+++ b/PhysicsEngine/PhysicsEngine/Body.cs
@@ -30,8 +30,8 @@ namespace PhysicsEngine
         #endregion Fields
 
         #region Properties
-
-        public int CacheId => cacheId;
+        static public int NumberOfMassiveBodies => numberOfMassiveBodies;
+        public int CacheId => cacheId;        
         public Vector3 CurrentAcceleration { get; set; } = Vector3.Zero;
         public Vector3 CurrentPosition { get; set; }
         public double CurrentPotentialEnergy { get; set; } = 0.0;
@@ -89,6 +89,7 @@ namespace PhysicsEngine
         }
 
         public void AppendPointToTrajectory(TrajectoryPoint pPoint) => trajectory.Add(pPoint);
+
         /// <summary>
         /// Evaluates the graviational force this body exerts on another body.
         /// </summary>
@@ -99,8 +100,8 @@ namespace PhysicsEngine
             if (isMassive)
             {
                 double squareDistance = Vector3.DistanceSquared(CurrentPosition, pBody.CurrentPosition);
-                double magnitude = (-1) * PhysicalConstants.G * mass * pBody.Mass / squareDistance;
-                Vector3 direction = (-1) * Vector3.Normalize(CurrentPosition - pBody.CurrentPosition);
+                double magnitude = PhysicalConstants.G * mass * pBody.Mass / squareDistance;
+                Vector3 direction = Vector3.Normalize(CurrentPosition - pBody.CurrentPosition);
                 return magnitude * direction;
             }
             else

--- a/PhysicsEngine/PhysicsEngine/Cache.cs
+++ b/PhysicsEngine/PhysicsEngine/Cache.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PhysicsEngine
+{
+    internal class Cache
+    {
+        int dimension;
+        double?[,] grid;
+
+        public Cache(int pDimension)
+        {
+            grid = new double?[pDimension, pDimension];
+        }
+
+        public double? Fetch(int i, int j)
+        {
+            if (i == j) throw new Exception("Diagonal elements cannot ever be fetched because they are undefined.");
+
+            if (j > i) return grid[j, i];
+
+            if (grid[i, j] is null) return null;
+
+            return grid[i, j];
+        }
+
+        public void Clear() => grid = new double?[dimension, dimension];
+        
+        public void Post(int i, int j, double pValue)
+        {
+            if (i == j) throw new Exception("Diagonal elements must remain undefined.");
+
+            if (grid[i, j] is not null) throw new Exception("Cache element is already initialized.");
+
+            if (j > i) Post(j, i, pValue);            
+
+            grid[i, j] = pValue;
+        }
+    }
+}

--- a/PhysicsEngine/PhysicsEngine/Cache.cs
+++ b/PhysicsEngine/PhysicsEngine/Cache.cs
@@ -6,17 +6,17 @@ using System.Threading.Tasks;
 
 namespace PhysicsEngine
 {
-    internal class Cache
+    internal class ForceCache
     {
         int dimension;
-        double?[,] grid;
+        Vector3?[,] grid;
 
-        public Cache(int pDimension)
+        public ForceCache(int pDimension)
         {
-            grid = new double?[pDimension, pDimension];
+            grid = new Vector3?[pDimension, pDimension];
         }
 
-        public double? Fetch(int i, int j)
+        public Vector3? Fetch(int i, int j)
         {
             if (i == j) throw new Exception("Diagonal elements cannot ever be fetched because they are undefined.");
 
@@ -27,9 +27,9 @@ namespace PhysicsEngine
             return grid[i, j];
         }
 
-        public void Clear() => grid = new double?[dimension, dimension];
+        public void Clear() => grid = new Vector3?[dimension, dimension];
         
-        public void Post(int i, int j, double pValue)
+        public void Post(int i, int j, Vector3 pValue)
         {
             if (i == j) throw new Exception("Diagonal elements must remain undefined.");
 

--- a/PhysicsEngine/PhysicsEngine/Cache.cs
+++ b/PhysicsEngine/PhysicsEngine/Cache.cs
@@ -8,11 +8,12 @@ namespace PhysicsEngine
 {
     internal class ForceCache
     {
-        int dimension;
+        readonly int dimension;
         Vector3?[,] grid;
 
         public ForceCache(int pDimension)
         {
+            dimension = pDimension;
             grid = new Vector3?[pDimension, pDimension];
         }
 

--- a/PhysicsEngine/PhysicsEngine/Cache.cs
+++ b/PhysicsEngine/PhysicsEngine/Cache.cs
@@ -6,10 +6,21 @@ using System.Threading.Tasks;
 
 namespace PhysicsEngine
 {
+    /// <summary>
+    /// Stores the gravitational forces the bodies each extert on the other bodies in the simulation.
+    /// They are stored in a upper triangular matrix of Vector3 objects to save memory.
+    /// </summary>
     internal class ForceCache
     {
+
+        #region Fields
+
         readonly int dimension;
         Vector3?[,] grid;
+
+        #endregion Fields
+
+        #region Public Constructors
 
         public ForceCache(int pDimension)
         {
@@ -17,28 +28,55 @@ namespace PhysicsEngine
             grid = new Vector3?[pDimension, pDimension];
         }
 
-        public Vector3? Fetch(int i, int j)
+        #endregion Public Constructors
+
+        #region Public Methods
+
+        public void Refresh(List<Body> bodies)
         {
-            if (i == j) throw new Exception("Diagonal elements cannot ever be fetched because they are undefined.");
+            Clear();
 
-            if (j > i) return grid[j, i];
-
-            if (grid[i, j] is null) return null;
-
-            return grid[i, j];
+            foreach (Body body1 in bodies)
+            {
+                foreach (Body body2 in bodies.Where(x => x.CacheId < body1.CacheId))
+                {
+                    Post(body1, body2);
+                }
+            }
         }
 
-        public void Clear() => grid = new Vector3?[dimension, dimension];
-        
-        public void Post(int i, int j, Vector3 pValue)
+        public Vector3 Fetch(Body body1, Body body2) => Fetch(body1.CacheId, body2.CacheId);
+
+        public void Post(Body body1, Body body2) => Post(body1.CacheId, body2.CacheId, body2.GetForceOn(body1));
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        Vector3 Fetch(int i, int j)
+        {
+            if (i == j) throw new ArgumentException("Diagonal elements cannot ever be fetched because they are undefined.", nameof(j));
+
+            if (i < j) return (-1) * Fetch(j, i); // prefactor comes from antisymmetry of force matrix
+
+            if (grid[i, j] is null) throw new Exception("Cache has not been initialized.");
+
+            return grid[i, j]!;
+        }
+        void Post(int i, int j, Vector3 pValue)
         {
             if (i == j) throw new Exception("Diagonal elements must remain undefined.");
 
             if (grid[i, j] is not null) throw new Exception("Cache element is already initialized.");
 
-            if (j > i) Post(j, i, pValue);            
+            if (j > i) throw new ArgumentException("Force cache must be upper triangular matrix.", nameof(j));
 
             grid[i, j] = pValue;
         }
+
+        void Clear() => grid = new Vector3?[dimension, dimension];
+
+        #endregion Private Methods
+
     }
 }

--- a/PhysicsEngine/PhysicsEngine/Engine.cs
+++ b/PhysicsEngine/PhysicsEngine/Engine.cs
@@ -70,6 +70,10 @@ namespace PhysicsEngine
                     CalculateNextPosition(pIsFirstStep, body);
                 }
             }
+
+            if (forceCache is null) throw new Exception("Force cache is not initialized.");
+
+            forceCache.Clear();
         }
 
         private void CalculateNextPosition(bool pIsFirstStep, Body pBody)
@@ -113,6 +117,8 @@ namespace PhysicsEngine
 
         private Vector3 GetForceBodyBOnA(Body pBodyA, Body pBodyB)
         {
+            if (forceCache is null) throw new Exception("Force cache is not initialized.");
+
             Vector3? cachedForce = forceCache.Fetch(pBodyA.CacheId, pBodyB.CacheId);
 
             if (cachedForce is null)

--- a/PhysicsEngine/PhysicsEngine/Program.cs
+++ b/PhysicsEngine/PhysicsEngine/Program.cs
@@ -132,13 +132,13 @@ namespace PhysicsEngine
 
 
             double timeSpan = 1 * 365 * 24 * Math.Pow(60, 2);
-            double timeResolution = Math.Pow(60, 2);
+            double timeResolution = 24 * Math.Pow(60, 2);
 
             Engine simulation = new(timeSpan, timeResolution, simulationBodies);
             Clock runtimeClock = new(simulation.Run);
 
             ////simulation.PrintToScreen();
-            //simulation.PrintToFile();
+            simulation.PrintToFile();
             //MakePlot();
             //Console.WriteLine("Plotting done!");
         }

--- a/PhysicsEngine/PhysicsEngine/Program.cs
+++ b/PhysicsEngine/PhysicsEngine/Program.cs
@@ -132,7 +132,7 @@ namespace PhysicsEngine
 
 
             double timeSpan = 1 * 365 * 24 * Math.Pow(60, 2);
-            double timeResolution = 24 * Math.Pow(60, 2);
+            double timeResolution = Math.Pow(60, 2);
 
             Engine simulation = new(timeSpan, timeResolution, simulationBodies);
             Clock runtimeClock = new(simulation.Run);

--- a/PhysicsEngine/PhysicsEngine/Program.cs
+++ b/PhysicsEngine/PhysicsEngine/Program.cs
@@ -137,10 +137,10 @@ namespace PhysicsEngine
             Engine simulation = new(timeSpan, timeResolution, simulationBodies);
             Clock runtimeClock = new(simulation.Run);
 
-            //simulation.PrintToScreen();
-            simulation.PrintToFile();
-            MakePlot();
-            Console.WriteLine("Plotting done!");
+            ////simulation.PrintToScreen();
+            //simulation.PrintToFile();
+            //MakePlot();
+            //Console.WriteLine("Plotting done!");
         }
 
         public static void MakePlot()


### PR DESCRIPTION
## What?
I have added memoization in the form of a cache for calculated force vectors. This includes a class for the force cache and implementation of it in the engine class.

## Why?
Caching the force values roughly cuts the simulation runtime in half. At the moment, we calculate all forces that n bodies exert on the other n bodies. But if body A exerts force F on body B, then body B exerts force -F on body A. Hence, we need not calculate this value twice but instead store the first calculation's result in a cache and then later retrieve it and apply the minus.

## How?
The class ForceCache is implemented in the Engine class as a member. It is initialized in the Run() method instead of in the constructor, so that additional bodies can still be added to the simulation before running. At the beginning of each call of ProceedOneStep(), the cache is refreshed with the new values. To save up on memory, the cache only stores one force value for each body-body pair, including the negative prefactor in the return values when the bodies are transposed. To identify the bodies, I have also implemented a cacheId member for the Body class, based off the number of massive bodies in the simulation.

## Testing?
Run the simulation against a simulation using the main branch with the solar system setup. Capture the runtimes. The results should be identical but the runtime should be shorter by roughly a factor of two.

## Screenshots (optional)

## Anything Else?
